### PR TITLE
fix(babel): missing @babel/runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
-# Changelog
+# 0.1.0 (2020-05-20)
 
-Here you can find a (pretty much) complete list of all changes/additions introduced with each version of the project!
+### Features
+
+- initial release ([c15d409](https://github.com/lukecarr/joodle/commit/c15d4093fe8ca559229a59162c4fca98ea5946ff))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "joodle",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -991,7 +991,6 @@
       "version": "7.9.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
       "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -15367,8 +15366,7 @@
     "regenerator-runtime": {
       "version": "0.13.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-      "dev": true
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regenerator-transform": {
       "version": "0.14.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joodle",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Moodle Web Service API client for Node.js.",
   "keywords": [
     "moodle",
@@ -77,6 +77,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
+    "@babel/runtime": "^7.9.6",
     "got": "^11.1.4",
     "qs": "^6.9.4"
   },


### PR DESCRIPTION
### Checklist

- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features).
- [x] Build (`npm run build`) was run locally and any changes were pushed.
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures.

### Current Behavior

`@babel/runtime` was missing as a dependency which resulted in errors when attempting to import joodle.

### New Behavior

`@babel/runtime` has been added as a dependency.

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
