### PR TITLE
fix: changed from export default to export in main file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-* **babel:** missing @babel/runtime dependency ([a1b79fb](https://github.com/lukecarr/joodle/commit/a1b79fbb787a417c035f9eb5e793d7a1a78dcbb7))
+- **babel:** missing @babel/runtime dependency ([a1b79fb](https://github.com/lukecarr/joodle/commit/a1b79fbb787a417c035f9eb5e793d7a1a78dcbb7))
 
 # 0.1.0 (2020-05-20)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "joodle",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joodle",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Moodle Web Service API client for Node.js.",
   "keywords": [
     "moodle",
@@ -20,6 +20,7 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "typings": "dist/index",
   "files": [
     "dist/"
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { Client, ClientOptions } from "./client";
 import AuthModule from "./modules/auth";
 
-export default class Joodle extends Client {
+// eslint-disable-next-line import/prefer-default-export
+export class Joodle extends Client {
   public auth: AuthModule;
 
   public constructor(options: ClientOptions) {


### PR DESCRIPTION
### Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features).
- [x] Build (`npm run build`) was run locally and any changes were pushed.
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures.

### Current Behavior

Importing joodle (either with `require('joodle')` or `import 'joodle'`) would throw an error because the `Joodle` class was the default export of joodle's main file.

### New Behavior

The `Joodle` class inside joodle's main file is now a named export.

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

