### PR TITLE
Feat response typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ The `baseURL` option should point to your Moodle website, and the `token` option
 
 #### Modules
 
-Joodle is split up into modules to mimic the way that Moodle's Web Services API has functions grouped by [their area](https://docs.moodle.org/dev/Web_service_API_functions).
+Joodle is split up into modules to mimic the way that Moodle's Web Services API has functions grouped by **[their area](https://docs.moodle.org/dev/Web_service_API_functions)**.
 
 All modules (and their web service functions) are accessible through your `Joodle` instance.
 
 For example: taking the first function listed on the aforementioned Moodle docs page.
 
-| Area       | Name                           |
+|    Area    |              Name              |
 | :--------: | :----------------------------: |
 | auth_email | auth_email_get_signup_settings |
 
@@ -114,5 +114,5 @@ This project uses the following open source packages:
 - **[Node.js](https://nodejs.org)**
 - **[TypeScript](https://www.typescriptlang.org)**
 - **[got](https://github.com/sindresorhus/got)**
-- **[ESLint](https://eslint.org)**
-- **[Prettier](https://prettier.io)**
+
+For a comprehensive list, see the **[package.json](package.json)** file's dependencies section.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "joodle",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joodle",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Moodle Web Service API client for Node.js.",
   "keywords": [
     "moodle",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,10 +1,20 @@
 import got, { Got } from "got";
 
 export interface ClientOptions {
+  /**
+   * The base URL of the Moodle site to send API requests to.
+   */
   baseURL: string;
+
+  /**
+   * The token used to authenticate with the Moodle site's Web Services API.
+   */
   token: string;
 }
 
+/**
+ * A client that can send HTTP requests to a Moodle site's Web Services API.
+ */
 export abstract class Client {
   private baseURL: string;
 
@@ -12,6 +22,12 @@ export abstract class Client {
 
   public got: Got;
 
+  /**
+   * Initializes the client as well as the client's `got` instance so HTTP
+   * requests can be made.
+   * 
+   * @param options The client's configuration options.
+   */
   public constructor(options: ClientOptions) {
     this.baseURL = options.baseURL;
     this.token = options.token;

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,7 +25,7 @@ export abstract class Client {
   /**
    * Initializes the client as well as the client's `got` instance so HTTP
    * requests can be made.
-   * 
+   *
    * @param options The client's configuration options.
    */
   public constructor(options: ClientOptions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,19 @@
 import { Client, ClientOptions } from "./client";
 import AuthModule from "./modules/auth";
 
+/**
+ * The main Joodle client class. Used to make API calls to Moodle's Web Services
+ * API.
+ */
 // eslint-disable-next-line import/prefer-default-export
 export class Joodle extends Client {
   public auth: AuthModule;
 
+  /**
+   * Initializes a new Joodle client instance for making API calls to Moodle's
+   * Web Services API.
+   * @param options The client's configuration options.
+   */
   public constructor(options: ClientOptions) {
     super(options);
     this.auth = new AuthModule(this);

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,12 @@
 import { Client } from "./client";
 
+/**
+ * Attempts to handle a JSON body returned by a call to Moodle's Web Services API.
+ * If the body contains an `exception` property, then the response is assumed to
+ * be erroneous, and a rejected Promise is returned.
+ * 
+ * @param body A JSON body returned by a Moodle API call.
+ */
 const handleResponse = async (body: unknown): Promise<unknown> => {
   if ((body as any).exception) {
     return Promise.reject(body);
@@ -7,6 +14,9 @@ const handleResponse = async (body: unknown): Promise<unknown> => {
   return body;
 };
 
+/**
+ * Represents a collection of Moodle Web Services API functions.
+ */
 export default abstract class Module {
   protected client: Client;
 
@@ -14,6 +24,12 @@ export default abstract class Module {
     this.client = client;
   }
 
+  /**
+   * Performs a GET request to Moodle's Web Services API.
+   * 
+   * @param wsfunction The name of the Moodle Web Services API function to invoke.
+   * @param searchParams Any additional GET parameters to include in the request.
+   */
   protected async get(
     wsfunction: string,
     searchParams?: any

--- a/src/module.ts
+++ b/src/module.ts
@@ -4,7 +4,7 @@ import { Client } from "./client";
  * Attempts to handle a JSON body returned by a call to Moodle's Web Services API.
  * If the body contains an `exception` property, then the response is assumed to
  * be erroneous, and a rejected Promise is returned.
- * 
+ *
  * @param body A JSON body returned by a Moodle API call.
  */
 const handleResponse = async (body: unknown): Promise<unknown> => {
@@ -26,7 +26,7 @@ export default abstract class Module {
 
   /**
    * Performs a GET request to Moodle's Web Services API.
-   * 
+   *
    * @param wsfunction The name of the Moodle Web Services API function to invoke.
    * @param searchParams Any additional GET parameters to include in the request.
    */

--- a/src/modules/auth/email.ts
+++ b/src/modules/auth/email.ts
@@ -5,18 +5,18 @@ export interface SignUpSettingsResponse {
    * The fields that a user can provide during sign up to identify their name.
    */
   namefields: string[];
-  
+
   /**
    * Users signing up to this Moodle site must use a password that meets this policy's requirements.
    */
   passwordpolicy: string;
-  
+
   warnings: unknown[];
 }
 
 /**
  * Functions relating to Moodle's email-based self-registration.
- * 
+ *
  * This module's function calls may throw errors if self registration is disabled.
  */
 export default class AuthEmailModule extends Module {
@@ -24,6 +24,8 @@ export default class AuthEmailModule extends Module {
    * Get the sign-up required settings and profile fields.
    */
   public async getSignUpSettings(): Promise<SignUpSettingsResponse> {
-    return (await this.get("auth_email_get_signup_settings")) as SignUpSettingsResponse;
+    return (await this.get(
+      "auth_email_get_signup_settings"
+    )) as SignUpSettingsResponse;
   }
 }

--- a/src/modules/auth/email.ts
+++ b/src/modules/auth/email.ts
@@ -1,10 +1,29 @@
 import Module from "../../module";
 
+export interface SignUpSettingsResponse {
+  /**
+   * The fields that a user can provide during sign up to identify their name.
+   */
+  namefields: string[];
+  
+  /**
+   * Users signing up to this Moodle site must use a password that meets this policy's requirements.
+   */
+  passwordpolicy: string;
+  
+  warnings: unknown[];
+}
+
+/**
+ * Functions relating to Moodle's email-based self-registration.
+ * 
+ * This module's function calls may throw errors if self registration is disabled.
+ */
 export default class AuthEmailModule extends Module {
   /**
-   * Get the signup required settings and profile fields.
+   * Get the sign-up required settings and profile fields.
    */
-  public async getSignUpSettings(): Promise<unknown> {
-    return this.get("auth_email_get_signup_settings");
+  public async getSignUpSettings(): Promise<SignUpSettingsResponse> {
+    return (await this.get("auth_email_get_signup_settings")) as SignUpSettingsResponse;
   }
 }

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -2,6 +2,9 @@ import Module from "../../module";
 import AuthEmailModule from "./email";
 import { Client } from "../../client";
 
+/**
+ * Functions relating to authentication in Moodle (specifically self-registration).
+ */
 export default class AuthModule extends Module {
   public email: AuthEmailModule;
 


### PR DESCRIPTION
### Checklist

- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features).
- [x] Build (`npm run build`) was run locally and any changes were pushed.
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures.

### Current Behavior

JSDocs are missing for most functions/classes and the `auth.email.getSignUpSettings()` response type is currently `Promise<unknown>`.

### New Behavior

Added missing JSDocs (now fully covered) and created an interface for `auth.email.getSignUpSettings()` to return (`SignUpSettingsResponse`).

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
